### PR TITLE
Remove quotes from generic font-family names

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install mkdocs && \
 RUN ./bin/build_docs.sh
 
 # Serve image (stable nginx version)
-FROM nginx:1.16
+FROM nginx:1.18
 
 LABEL description="dcrdevdocs serve"
 LABEL version="1.0"

--- a/docs/css/fonts.css
+++ b/docs/css/fonts.css
@@ -53,13 +53,11 @@
 }
 
 html, body {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrdevdocs", "Verdana", "sans-serif" !important;
+    font-family: "dcrdevdocs", "Verdana", sans-serif;
 }
 
 pre, code {
-    /* use !important to prevent issues with browser extensions that change fonts */
-    font-family: "dcrdevdocs-code", "Courier New", "monospace" !important;
+    font-family: "dcrdevdocs-code", "Courier New", monospace;
 }
 
 .md-typeset h1 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.1.0
-mkdocs-material==5.1.4
-mkdocs-material-extensions==1.0b2
-mkdocs-markdownextradata-plugin==0.1.3
+mkdocs==1.1.2
+mkdocs-material==5.3.0
+mkdocs-material-extensions==1.0
+mkdocs-markdownextradata-plugin==0.1.6


### PR DESCRIPTION
Discovered in decred/dcrdocs#1103, generic font-family names should not have quotes: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

Also taken the opportunity to update build deps.