### PR TITLE
Update mkdocs and python.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM python:3.8
+FROM python:3.9
 
 LABEL description="dcrdevdocs build"
 LABEL version="1.0"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ dcrdevdocs
 
 In order to develop on `dcrdocs` you will need [Python](https://www.python.org/)
 installed on your system.
-Version 3.8 is recommended because this is the version used by the live site,
-however MkDocs does also support versions 3.5 and later.
+Version 3.9 is recommended because this is the version used by the live site,
+however MkDocs does also support versions 3.6 and later.
 Python 2 is not supported.
 
 You can verify your installation of Python by checking the output from these two
@@ -23,9 +23,9 @@ commands:
 
 ```bash
 $ python --version
-Python 3.8.2
+Python 3.9.5
 $ pip --version
-pip 20.0.2
+pip 21.1.2
 ```
 
 #### Install dependencies
@@ -42,22 +42,20 @@ This repo contains a single configuration file named `mkdocs.yml`, and a folder 
 
 ```bash
 $ mkdocs serve
-INFO    -  Building documentation...
-INFO    -  Cleaning site directory
-[I 160402 15:50:43 server:271] Serving on http://127.0.0.1:8000
-[I 160402 15:50:43 handlers:58] Start watching changes
-[I 160402 15:50:43 handlers:60] Start detecting changes
+INFO     -  Building documentation...
+INFO     -  Cleaning site directory
+INFO     -  Documentation built in 9.09 seconds
+INFO     -  [13:26:55] Serving on http://127.0.0.1:8000/
 ```
 
 If you are using Windows, you may need to inform python to search sys.path for the mkdocs module:
 
 ```bash
 $ python -m mkdocs serve
-INFO    -  Building documentation...
-INFO    -  Cleaning site directory
-[I 190207 18:05:35 server:298] Serving on http://127.0.0.1:8000
-[I 190207 18:05:35 handlers:59] Start watching changes
-[I 190207 18:05:35 handlers:61] Start detecting changes
+INFO     -  Building documentation...
+INFO     -  Cleaning site directory
+INFO     -  Documentation built in 9.09 seconds
+INFO     -  [13:26:55] Serving on http://127.0.0.1:8000/
 ```
 
 Open up <http://127.0.0.1:8000> in your browser, and you will see the documentation home page being displayed. The dev-server also supports auto-reloading, and will rebuild your documentation whenever anything in the configuration file or the documentation directory changes.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -129,6 +129,14 @@ details .md-typeset__table code{
     white-space: nowrap;
 }
 
+.md-typeset table:not([class]) {
+    border: 0;
+    box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.05rem rgb(0 0 0 / 10%);
+}
+.md-typeset table:not([class]) tr:first-child td {
+    border-top: 0;
+}
+
 /* Don't wrap code blocks in tables onto multiple lines in opcodes.md or blockchain-parameters.md */
 #opcodes ~ div .md-typeset__table code,
 #blockchain-parameters ~ div .md-typeset__table code {
@@ -147,6 +155,10 @@ details .md-typeset__table code{
 
 .md-typeset .admonition p{
     font-size: 14px;
+}
+
+.md-typeset blockquote p{
+    padding: 12px 0 12px;
 }
 
 .md-typeset code {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Decred Developer Documentation
+use_directory_urls: true
 theme:
   name: material
   favicon: 'img/favicon.ico?v=s3ss'
@@ -63,7 +64,7 @@ markdown_extensions:
   - markdown.extensions.smarty
   - markdown.extensions.admonition
   - markdown.extensions.toc:
-      permalink: True
+      permalink: true
   - markdown.extensions.tables
   - markdown.extensions.attr_list
   - pymdownx.details

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs==1.2.2
-mkdocs-material==7.2.2
-mkdocs-material-extensions==1.0.1
+mkdocs-material==7.2.6
 mkdocs-markdownextradata-plugin==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.1.2
-mkdocs-material==7.1.4
+mkdocs==1.2.2
+mkdocs-material==7.2.2
 mkdocs-material-extensions==1.0.1
 mkdocs-markdownextradata-plugin==0.2.4


### PR DESCRIPTION
No major breaking changes introduced by mkdocs 1.2. ~The only required change is setting site_url in mkdocs.yml.~ No longer needed in 1.2.2

Mkdocs now officially supports python 3.9 and has dropped 3.5 support.

### Update (14/09/2021)

Now includes updating mkdocs-material to 7.2.6