### PR TITLE
Update to mkdocs-material 8.2.8, and link to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ INFO     -  [13:26:55] Serving on http://127.0.0.1:8000/
 
 Open up <http://127.0.0.1:8000> in your browser, and you will see the documentation home page being displayed. The dev-server also supports auto-reloading, and will rebuild your documentation whenever anything in the configuration file or the documentation directory changes.
 
+#### Formatting
+
+In general, stick to standard Markdown formatting. However, these docs use [Material for Mkdocs](https://squidfunk.github.io/mkdocs-material/reference/), so consult their documentation if you need additional formatting tools.
+
+
 ## Deploying
 
 To deploy `dcrdevdocs`, first build the documentation:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==8.0.1
+mkdocs-material==8.2.8
 mkdocs-markdownextradata-plugin==0.2.4


### PR DESCRIPTION
Wanted to directly link to the Material for Mkdocs documentation, because I had forgotten how to use their annotations and admonitions.

Also, updated to the latest version of mkdocs. Notable changes for us since 8.0.1:
* Bumps MkDocs version to 1.3.0
* Added native support for Mermaid.js diagrams
* Added native support for tags
* Lots of general improvements for code annotations
* General improvements for admonitions
* Fixed table of contents on large screens
* Bugfixes